### PR TITLE
feat: output actual non-ascii characters instead of Unicode code

### DIFF
--- a/.github/workflows/code-formatting.yaml
+++ b/.github/workflows/code-formatting.yaml
@@ -1,4 +1,4 @@
-name: Code formatting
+name: Code Formatting
 
 on:
   push:
@@ -22,8 +22,9 @@ jobs:
       with:
         python-version: 3.11
 
-    - name: Install dependencies
-      run: pip install black
+    - name: Install packages
+      run: |
+        pip install ".[code-formatting]"
 
     - name: Run black check
       run: black --check .

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,4 @@
-name: Publish Python distribution
+name: Publish Python Distribution
 
 on:
   push:
@@ -35,8 +35,8 @@ jobs:
 
     - name: Install pypa/build
       if: steps.check-version.outputs.version != ''
-      run: >-
-        python3 -m pip install build --user
+      run: |
+        pip install ".[publish]"
 
     - name: Build a binary wheel and a source tarball
       if: steps.check-version.outputs.version != ''

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,11 +25,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: pip install pytest
-
-    - name: Install package
-      run: pip install .
+    - name: Install packages
+      run: |
+        pip install ".[tests]"
 
     - name: Run tests
       run: pytest tests/

--- a/.github/workflows/type-checks.yaml
+++ b/.github/workflows/type-checks.yaml
@@ -22,10 +22,9 @@ jobs:
       with:
         python-version: 3.11
 
-    - name: Install dependencies
+    - name: Install packages
       run: |
-        pip install mypy
-        pip install types-pyyaml
+        pip install ".[type-checks]"
 
     - name: Run mypy checks
-      run: mypy cels/
+      run: mypy .

--- a/cels/cli/patch.py
+++ b/cels/cli/patch.py
@@ -133,8 +133,8 @@ def cels_patch(
     output_format = output_format.lower()
 
     # compose output
-    input_text = input_file.read_text()
-    patch_text = patch_file.read_text()
+    input_text = input_file.read_text(encoding="utf-8")
+    patch_text = patch_file.read_text(encoding="utf-8")
     try:
         output_text = patch_document(
             input_format=input_format,
@@ -153,7 +153,7 @@ def cels_patch(
 
     # save result
     try:
-        with click.open_file(output_file, "w") as f:
+        with click.open_file(output_file, "w", encoding="utf-8") as f:
             f.write(output_text)
     except OSError as err:
         log.error(f"Error found when saving output file: {err}")

--- a/cels/models/operation.py
+++ b/cels/models/operation.py
@@ -72,7 +72,7 @@ class Operation:
         return cls.instances[name]
 
     @classmethod
-    def get_all(cls) -> "list[Operation]":
+    def get_all(cls) -> "List[Operation]":
         return list(cls.instances.values())
 
     def __str__(self):

--- a/cels/services/patch_document.py
+++ b/cels/services/patch_document.py
@@ -31,8 +31,8 @@ dump_functions: Dict[str, Callable] = {
 }
 
 dump_parameters: Dict[str, Dict[str, Any]] = {
-    "yaml": {"sort_keys": False},
-    "json": {"indent": 2},
+    "yaml": {"sort_keys": False, "allow_unicode": True},
+    "json": {"indent": 2, "ensure_ascii": False},
     "toml": {},
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,24 @@ dependencies = [
 "Homepage" = "https://github.com/pacha/cels"
 "Bug Tracker" = "https://github.com/pacha/cels/issues"
 
+[project.optional-dependencies]
+dev = [
+  "cels[tests,type-checks,code-formatting]",
+]
+tests = [
+  "pytest",
+]
+type-checks = [
+  "mypy",
+  "types-pyyaml",
+]
+code-formatting = [
+  "black",
+]
+publish = [
+  "build",
+]
+
 [project.scripts]
 cels = "cels.cli:cels"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cels"
-version = "0.1.3"
+version = "0.1.4"
 authors = [
     {name="Andrés Sopeña Pérez", email="code@ehmm.org"},
 ]

--- a/tests/test_format_json.py
+++ b/tests/test_format_json.py
@@ -13,3 +13,32 @@ def test_json_multiple_changes(fixtures_path):
 
     output = patch_json(input, patch).strip()
     assert output == result
+
+
+def test_json_special_chars():
+    input = cleandoc(
+        """
+    {
+      "Name": "María",
+      "Straße": "221B Baker Street"
+    }
+    """
+    )
+    patch = cleandoc(
+        """
+    {
+      "Name": "Jörg"
+    }
+    """
+    )
+    result = cleandoc(
+        """
+    {
+      "Name": "Jörg",
+      "Straße": "221B Baker Street"
+    }
+    """
+    )
+
+    output = patch_json(input, patch).strip()
+    assert output == result

--- a/tests/test_format_yaml.py
+++ b/tests/test_format_yaml.py
@@ -368,3 +368,30 @@ def test_yaml_multiple_changes(fixtures_path):
 
     output = patch_yaml(input, patch).strip()
     assert output == result
+
+
+def test_yaml_special_chars():
+    input = cleandoc(
+        """
+
+    Name: "María"
+    Straße: "221B Baker Street"
+
+    """
+    )
+    patch = cleandoc(
+        """
+    Name: "Jörg"
+    """
+    )
+    result = cleandoc(
+        """
+
+    Name: Jörg
+    Straße: 221B Baker Street
+
+    """
+    )
+
+    output = patch_yaml(input, patch).strip()
+    assert output == result


### PR DESCRIPTION
Cels outputs non-ascii characters using the Unicode code instead of the actual character. Instead of:
```
{
  "Name": "Jörg",
  "Straße": "221B Baker Street"
}
```
it shows:
```
{
  "Name": "J\u00f6rg",
  "Stra\u00dfe": "221B Baker Street"
}
```
This happens in both the YAML and JSON outputs. This PR solves that problem, and makes the tool to output the actual character (which is much more human friendly).